### PR TITLE
fix spelling of "cold" in team office description

### DIFF
--- a/src/main/java/de/derkomischeagilist/Rooms/TeamOffice.java
+++ b/src/main/java/de/derkomischeagilist/Rooms/TeamOffice.java
@@ -20,7 +20,7 @@ public class TeamOffice extends AbstractRoom {
 
     @Override
     public String getDescription() {
-        return "This is a very stinky room. Smells like real work and you can feel the Cold atmosphere inside the room. \n" +
+        return "This is a very stinky room. Smells like real work and you can feel the cold atmosphere inside the room. \n" +
         		"In the middle of the room there are several dirty old cubicles. " +
                 "Nearly each one of the cubicles has a worker in front of it staring directly at the computer screen. \n" +
                 "Your smart but smelly Teammates greet you in the usual manner: 'Hey, you moron! ;)', " +

--- a/src/test/java/de/derkomischeagilist/AdventureTest.java
+++ b/src/test/java/de/derkomischeagilist/AdventureTest.java
@@ -196,7 +196,7 @@ public class AdventureTest {
     	//When I go into the team office
         String actual = adventure.tell("use door to team office");
         //Then I can see cubicles and workers
-        assertThat(actual, containsStringIgnoringCase("This is a very stinky room. Smells like real work and you can feel the Cold atmosphere inside the room. \n" +
+        assertThat(actual, containsStringIgnoringCase("This is a very stinky room. Smells like real work and you can feel the cold atmosphere inside the room. \n" +
         		"In the middle of the room there are several dirty old cubicles. Nearly each one of the cubicles has a worker in front of it staring directly at the computer screen. \n" +
                 "Your smart but smelly Teammates greet you in the usual manner: 'Hey, you moron! ;)'"));
         //When I look around


### PR DESCRIPTION
Word "cold" in team office description was wrongly capitalized. Was changed to small letter.